### PR TITLE
193 altro setup poc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.toc
 *.lot
 *.lof
+*.env
+node_modules/

--- a/poc/Makefile
+++ b/poc/Makefile
@@ -1,0 +1,7 @@
+default: rebuild
+
+rebuild:
+	-clear
+	docker compose down -v --remove-orphans
+	docker compose up -d --build
+	-docker compose logs -f

--- a/poc/backend/.dockerignore
+++ b/poc/backend/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/poc/backend/Dockerfile
+++ b/poc/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/poc/backend/main.py
+++ b/poc/backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/api/status")
+async def status():
+    return "ok", 200

--- a/poc/backend/requirements.txt
+++ b/poc/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/poc/docker-compose.yml
+++ b/poc/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  frontend:
+    container_name: frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    stdin_open: true
+    tty: true
+    depends_on:
+      backend:
+        condition: service_started
+
+  backend:
+    container_name: backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+    environment:
+      - PYTHONUNBUFFERED=1

--- a/poc/frontend/.dockerignore
+++ b/poc/frontend/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+node_modules/

--- a/poc/frontend/Dockerfile
+++ b/poc/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+COPY . .
+
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/poc/frontend/index.html
+++ b/poc/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Markdown Editor</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/poc/frontend/package.json
+++ b/poc/frontend/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "prova_editor",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "run-p type-check \"build-only {@}\" --",
+    "preview": "vite preview",
+    "build-only": "vite build",
+    "type-check": "vue-tsc --build",
+    "lint": "run-s lint:*",
+    "lint:oxlint": "oxlint . --fix",
+    "lint:eslint": "eslint . --fix --cache",
+    "format": "prettier --write --experimental-cli src/"
+  },
+  "dependencies": {
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language-data": "^6.5.2",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.43.0",
+    "codemirror": "^6.0.2",
+    "marked": "^18.0.4",
+    "pinia": "^3.0.4",
+    "vue": "^3.5.32",
+    "vue-codemirror6": "^1.5.2",
+    "vue-router": "^5.0.4"
+  },
+  "devDependencies": {
+    "@tsconfig/node24": "^24.0.4",
+    "@types/node": "^24.12.2",
+    "@vitejs/plugin-vue": "^6.0.6",
+    "@vue/eslint-config-typescript": "^14.7.0",
+    "@vue/tsconfig": "^0.9.1",
+    "eslint": "^10.2.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-oxlint": "~1.60.0",
+    "eslint-plugin-vue": "~10.8.0",
+    "jiti": "^2.6.1",
+    "npm-run-all2": "^8.0.4",
+    "oxlint": "~1.60.0",
+    "prettier": "3.8.3",
+    "typescript": "~6.0.0",
+    "vite": "^8.0.8",
+    "vite-plugin-vue-devtools": "^8.1.1",
+    "vue-tsc": "^3.2.6"
+  }
+}

--- a/poc/frontend/src/App.vue
+++ b/poc/frontend/src/App.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import Codemirror from 'vue-codemirror6'
+import { markdown } from '@codemirror/lang-markdown'
+import { languages } from '@codemirror/language-data'
+import { oneDark } from '@codemirror/theme-one-dark'
+import { marked } from 'marked'
+
+const code = ref<string>('# Ciao Mondo!\n\nScrivi qui il tuo **Markdown**.')
+const extensions = [markdown({ codeLanguages: languages }), oneDark]
+const compiledMarkdown = computed(() => {
+  return marked(code.value) as string
+})
+
+// - - - - - TEST API - - - - -
+const apiStatus = ref<string>('Verifica connessione al backend in corso...')
+
+const testConnessione = async () => {
+  try {
+    const response = await fetch('/api/status')
+
+    if (!response.ok) {
+      throw new Error(`Errore del server backend: ${response.status} ❌`)
+    }
+
+    const response_status = await response.status
+    apiStatus.value = `✅ Connesso al server backend, ${response_status} ✅`
+
+  } catch (error) {
+    apiStatus.value = `❌ Connessione al backend fallita: ${error instanceof Error ? error.message : 'Errore sconosciuto ❌'}`
+  }
+}
+
+// Esegui il test quando il componente viene montato
+onMounted(() => {
+  testConnessione()
+})
+</script>
+
+<template>
+  <div class="api-banner" :class="{ 'error': apiStatus.includes('❌'), 'connected': apiStatus.includes('✅') }"> {{ apiStatus }} </div>
+
+  <div class="editor-container">
+    <!-- Editor panel -->
+    <div class="editor-panel">
+      <Codemirror v-model="code" :extensions="extensions" :basic="true" :dark="true" :wrap="true"
+        placeholder="Scrivi qui il tuo Markdown..." />
+    </div>
+
+    <!-- Preview panel -->
+    <div class="preview-panel">
+      <div class="preview-content" v-html="compiledMarkdown"></div>
+    </div>
+  </div>
+</template>
+
+
+<!--css-->
+<style scoped>
+.api-banner {
+  background-color: #707070;
+  color: white;
+  padding: 0.5rem 1rem;
+  font-family: monospace;
+  font-size: 0.9rem;
+  text-align: center;
+}
+.api-banner.error {
+  background-color: #c62828;
+}
+.api-banner.connected {
+  background-color: #2e7d32;
+}
+
+.editor-container {
+  display: flex;
+  gap: 1rem;
+  height: 100vh;
+  padding: 1rem;
+  background-color: #1e1e2f;
+  /* sfondo scuro per abbinare il tema */
+}
+
+.editor-panel,
+.preview-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  border-radius: 8px;
+  background-color: #282c34;
+}
+
+/* Assicura che l'editor occupi tutto lo spazio del pannello */
+.editor-panel :deep(.cm-editor) {
+  height: 100%;
+}
+
+.preview-content {
+  padding: 1rem;
+  color: #e0e0e0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  overflow-y: auto;
+}
+
+/* Stili base per l'HTML generato (Markdown) */
+.preview-content h1,
+.preview-content h2,
+.preview-content h3 {
+  color: #ffffff;
+}
+
+.preview-content code {
+  background-color: #3a3f4b;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: monospace;
+}
+
+.preview-content pre {
+  background-color: #1e1e2f;
+  padding: 0.5rem;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.preview-content a {
+  color: #61dafb;
+}
+</style>

--- a/poc/frontend/src/main.js
+++ b/poc/frontend/src/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/poc/frontend/vite.config.js
+++ b/poc/frontend/vite.config.js
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    host: '0.0.0.0',
+    watch: {
+      usePolling: true
+    },
+    allowedHosts: true,
+    // redirect all "/api" calls to backend container
+    proxy: {
+      '/api': {
+        target: 'http://backend:8000',
+        changeOrigin: true
+      }
+    }
+  }
+})


### PR DESCRIPTION
Aggiunto setup per il poc
2 moduli (e container) docker:
- frontend (vue js, CodeMirror)
- backend (Python e FastAPI)

N.B. i container devono essere riavviati solo in caso di aggiunta/rimozione librerie (comando: "make"), le modifiche sui file sia per backend sia per frontend si aggiornano "on the go" automaticamente grazie a componenti delle librerie fatte apposta per programmatori